### PR TITLE
fix: add Elixir 1.19 type system compatibility

### DIFF
--- a/lib/mix/tasks/live_state.gen.element.ex
+++ b/lib/mix/tasks/live_state.gen.element.ex
@@ -16,7 +16,6 @@ defmodule Mix.Tasks.LiveState.Gen.Element do
     * a channel test in `test/my_app_web/channels`
   """
   use Mix.Task
-  alias Mix.Tasks.Phx.Gen
 
   @doc false
   def run(args) do


### PR DESCRIPTION
Hi @superchris ,

  I hope this PR helps reduce Elixir warnings when using LiveState with Elixir 1.19. I'd appreciate if you could review and
  merge if everything looks good. I used AI assistance to develop this solution as I'm relatively new to Elixir.

  ## Summary
  Fixes type inference warnings introduced in Elixir 1.19's enhanced type system:

  - Fix "expected a module" warnings by normalizing @message_builder at compile time
  - Fix "unreachable clause" warnings by using proper with expressions and case statements  
  - Fix "never used" warnings by consolidating handle_init_result function clauses
  - Add missing lvs_refresh handler for complete Phoenix Channel compatibility
  - Use function_exported?/3 for robust message builder arity detection
  - Remove unused alias in mix task

  ## Compatibility
  Changes maintain full backward compatibility with existing LiveState applications while eliminating all type system 
  violations in Elixir 1.19.

  ## Testing
  - All existing tests continue to pass (32/32)
  - No warnings when compiling with Elixir 1.19
  - Tested with both default and custom message builders