### PR TITLE
Introduce handle_message/3 callback

### DIFF
--- a/test/sockety_channel_test.exs
+++ b/test/sockety_channel_test.exs
@@ -35,4 +35,13 @@ defmodule LiveState.SocketyChannelTest do
     })
   end
 
+  test "handle_message", %{socket: socket} do
+    send(socket.channel_pid, "message too")
+
+    assert_push("state:patch", %{
+      version: 1,
+      patch: [%{"op" => "replace", "path" => "/foo", "value" => "altered bar"}]
+    })
+  end
+
 end

--- a/test/support/sockety_channel.ex
+++ b/test/support/sockety_channel.ex
@@ -12,5 +12,9 @@ defmodule LiveState.Test.SocketyChannel do
   def handle_event("something_sockety", %{"baz" => new_baz}, %{foo: foo}, %{assigns: %{baz: baz}} = socket) do
     {:noreply, %{foo: "altered #{foo}"}, socket |> assign(:baz, new_baz)}
   end
-
+  
+  @impl true
+  def handle_message("message too", %{foo: foo}, %{assigns: %{baz: baz}} = socket) do
+    {:noreply, %{foo: "altered #{foo}"}, socket}
+  end
 end


### PR DESCRIPTION
LiveState overrides `handle_info` callback, which makes it hard to handle arbitrary messages, like [task results](https://hexdocs.pm/elixir/Task.Supervisor.html#async_nolink/3-compatibility-with-otp-behaviours), for example. Luckily, those messages eventually passed to `handle_message` callback, but this callback does only have access to the state, and not the socket. This PR introduces `handle_message/3` that can also handle socket, the same way `handle_event/4` does